### PR TITLE
Palette.dctl: Fix up compilation errors in DaVinci Resolve 19

### DIFF
--- a/Charts/Palette.dctl
+++ b/Charts/Palette.dctl
@@ -1,60 +1,60 @@
 // Palette DCTL
 
-__DEVICE__ float3 palette[27];  //p+1;
+__DEVICE__ __constant float3 palette[27] = {
+	make_float3(0.0f,0.0f,0.0f),
+	make_float3(0.0f,0.0f,0.5f),
+	make_float3(0.0f,0.0f,1.0f),
+	make_float3(0.5f,0.0f,0.0f),
+	make_float3(0.5f,0.0f,0.5f),
+	make_float3(0.5f,0.0f,1.0f),
+	make_float3(1.0f,0.0f,0.0f),
+	make_float3(1.0f,0.0f,0.5f),
+	make_float3(1.0f,0.0f,1.0f),
+	make_float3(0.0f,0.5f,0.0f),
+	make_float3(0.0f,0.5f,0.5f),
+	make_float3(0.0f,0.5f,1.0f),
+	make_float3(0.5f,0.5f,0.0f),
+	make_float3(0.5f,0.5f,0.5f),
+	make_float3(0.5f,0.5f,1.0f),
+	make_float3(1.0f,0.5f,0.0f),
+	make_float3(1.0f,0.5f,0.5f),
+	make_float3(1.0f,0.5f,1.0f),
+	make_float3(0.0f,1.0f,0.0f),
+	make_float3(0.0f,1.0f,0.5f),
+	make_float3(0.0f,1.0f,1.0f),
+	make_float3(0.5f,1.0f,0.0f),
+	make_float3(0.5f,1.0f,0.5f),
+	make_float3(0.5f,1.0f,1.0f),
+	make_float3(1.0f,1.0f,0.0f),
+	make_float3(1.0f,1.0f,0.5f),
+	make_float3(1.0f,1.0f,1.0f),
+};  //p+1;
 
 
-__DEVICE__ float3 getcolor(float c) 
+__DEVICE__ float3 getcolor(float c)
 {
-	c = _fmod(c, 27.0f); 
+	c = _fmod(c, 27.0f);
 	int p = 0;
 	float3 color = make_float3(0.0f, 0.0f, 0.0f);
 	for(int i = 0; i < 27; i++) {
-		if (float(i) - c <= 0.0f) { 
-			color = palette[i]; 
+		if ((float)(i) - c <= 0.0f) {
+			color = palette[i];
 		}
 	}
 	return color;
 }
-	
+
 __DEVICE__ float3 transform(int p_Width, int p_Height, int p_X, int p_Y, __TEXTURE__ p_TexR, __TEXTURE__ p_TexG, __TEXTURE__ p_TexB)
 {
-	palette[0] = make_float3(0.0f,0.0f,0.0f);
-	palette[1] = make_float3(0.0f,0.0f,0.5f);
-	palette[2] = make_float3(0.0f,0.0f,1.0f);
-	palette[3] = make_float3(0.5f,0.0f,0.0f);
-	palette[4] = make_float3(0.5f,0.0f,0.5f);
-	palette[5] = make_float3(0.5f,0.0f,1.0f);
-	palette[6] = make_float3(1.0f,0.0f,0.0f);
-	palette[7] = make_float3(1.0f,0.0f,0.5f);
-	palette[8] = make_float3(1.0f,0.0f,1.0f); 	
-	palette[9] = make_float3(0.0f,0.5f,0.0f);  	
-	palette[10] = make_float3(0.0f,0.5f,0.5f);  	
-	palette[11] = make_float3(0.0f,0.5f,1.0f);  	
-	palette[12] = make_float3(0.5f,0.5f,0.0f);  	
-	palette[13] = make_float3(0.5f,0.5f,0.5f);  
-	palette[14] = make_float3(0.5f,0.5f,1.0f);  
-	palette[15] = make_float3(1.0f,0.5f,0.0f);  	
-	palette[16] = make_float3(1.0f,0.5f,0.5f);  
-	palette[17] = make_float3(1.0f,0.5f,1.0f);  
-	palette[18] = make_float3(0.0f,1.0f,0.0f);  	
-	palette[19] = make_float3(0.0f,1.0f,0.5f);  	
-	palette[20] = make_float3(0.0f,1.0f,1.0f);  	
-	palette[21] = make_float3(0.5f,1.0f,0.0f);  	
-	palette[22] = make_float3(0.5f,1.0f,0.5f);  
-	palette[23] = make_float3(0.5f,1.0f,1.0f);  
-	palette[24] = make_float3(1.0f,1.0f,0.0f);  	
-	palette[25] = make_float3(1.0f,1.0f,0.5f);
-	palette[26] = make_float3(1.0f,1.0f,1.0f);
-	
 	float3 color = make_float3(0.0f,0.0f,0.0f);
-	
+
 	float iTime = _tex2D(p_TexR, 500, 500) / 24.0f;
 	float X = (float)p_X;
 	float Y = (float)(p_Height - p_Y);
 	float2 resolution = make_float2((float)p_Width, (float)p_Height);
 	float2 uv = make_float2(X / resolution.x, Y / resolution.y);
-	
+
 	if (uv.y < 1.0f && uv.y > 0.25f) color = getcolor(uv.x * 27.0f + iTime * 0.5f);
-	
+
 	return color;
-}	
+}


### PR DESCRIPTION
Fixes the following errors:

```
Build Options:  -w -DDEVICE_IS_OPENCL -DCOMPILER_IS_DVIP_RT -DKERNEL_TYPE_IS_DCTL -DVENDOR_IS_AMD -cl-mad-enable -cl-fast-relaxed-math Build Log:
/tmp/[...]/input/CompileSource:1817:19: error: program scope variable must reside in constant address space
 1817 | __DEVICE__ float3 palette[27];
      |                   ^
/tmp/[...]/input/CompileSource:1826:7: error: expected expression
 1826 |                 if (float(i) - c <= 0.0f) {
      |                     ^
2 errors generated.
Error: Failed to compile source (from CL or HIP source to LLVM IR).
```